### PR TITLE
Refactor: CI/CD more tweaks for testing

### DIFF
--- a/.github/workflows/bump-version-pr.yml
+++ b/.github/workflows/bump-version-pr.yml
@@ -24,6 +24,36 @@ jobs:
             - name: Create Release Pull Request or Publish
               id: changesets
               uses: changesets/action@v1
+              with:
+                # this should create the github tags hopefully
+                publish: yarn changeset tag
               env:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
+
+            - name: Get Latest Release id
+              id: get_latest_release_id
+              uses: actions/github-script@v6
+              with:
+                script: |
+                  const { data } = await github.rest.repos.getLatestRelease({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo
+                  })
+    
+                  return data.id
+    
+            - name: Set latest release to draft
+              uses: actions/github-script@v6
+              env:
+                release_id: ${{ steps.get_latest_release_id.outputs.result }}
+              with:
+                script: |
+                  github.rest.repos.updateRelease({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    release_id: process.env.release_id,
+                    draft: true,
+                    prerelease: false
+                  })
               

--- a/.github/workflows/develop-pr-tests.yml
+++ b/.github/workflows/develop-pr-tests.yml
@@ -1,5 +1,5 @@
 #test to run when there is a PR to the develop branch
-name: CI
+name: Develop PR tests
 on:
     pull_request:
         branches:


### PR DESCRIPTION
- Renamed `test.yml -> develop-pr-tests.yml` to make it easy to recognise
- Followed a blog on [devops with tauri](https://royserg.hashnode.dev/bearboard-4-devops) where the author used the semantic release package instead of changesets
- After some digging in the changeset issues section was able to see that the action doesnt create the release and tags on github unless the publish keyword is used. Due to the unique situation of using tauri and this isnt being published to npm some people were using dummy commands so that it could trigger the creation of the tag. In this cause I will use the `changeset tag` command to create a git tag which could be then used by the rest of the 