### PR TITLE
fix: added output for rest of the script

### DIFF
--- a/.github/workflows/bump-version-pr.yml
+++ b/.github/workflows/bump-version-pr.yml
@@ -9,7 +9,9 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
     create-release:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
+        outputs:
+          latest_release_id: ${{ steps.get_latest_release_id.outputs.result }}
         steps:
             - uses: actions/checkout@v3
 


### PR DESCRIPTION
Should be the final test that should allow the workflow to create a release for the repo

- added an output that would save the latest id that is created when the create release job is done